### PR TITLE
remove consul schema in order to use http and https

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 const MAJOR uint = 1
 const MINOR uint = 0
-const PATCH uint = 0
+const PATCH uint = 1
 
 func GetVersion() string {
 	return fmt.Sprintf("%d.%d.%d", MAJOR, MINOR, PATCH)

--- a/pkg/service/consul_service_monitoring.go
+++ b/pkg/service/consul_service_monitoring.go
@@ -40,7 +40,6 @@ func NewConsulServiceMonitor(cache cache.Cache, updateChan chan struct{}, addres
 	}
 	config := api.DefaultConfig()
 	config.Address = address
-	config.Scheme = "https"
 	config.TLSConfig.InsecureSkipVerify = helper.SkipTlsVerification
 	client, err := api.NewClient(config)
 	if err != nil {


### PR DESCRIPTION
Hi Julian,

I removed the hardcoded `https` schema used to connect to Consul. This setting prevented the use of HTTP. With the changes, it's possible to use HTTP (for testing) and HTTP setups.
Please review it and approve if it makes sense to you.

Thanks,
Severin